### PR TITLE
Исправление логики пригласительных сигналов

### DIFF
--- a/lua/entities/gmod_track_signal/init.lua
+++ b/lua/entities/gmod_track_signal/init.lua
@@ -307,15 +307,17 @@ function ENT:PostInitalize()
 	if not self.RouteNumberSetup or not self.RouteNumberSetup:find("W") then
 		self.GoodInvationSignal = 0
 		local index = 1
+		local white_lenses = {}
 		local after_red = false
 		for k,v in ipairs(self.Lenses) do
-			if v == "M" then continue end
-			for i = 1,#v do
-				if v[i] == "R" then after_red = true end
-				if v[i] == "W" and after_red then self.GoodInvationSignal = index end
-				index = index + 1
+			if v != "M" then
+				for i = 1,#v do
+					if i == #v and v[i] == "W" then table.insert(white_lenses, index) end
+					index = index + 1
+				end
 			end
 		end
+		self.GoodInvationSignal = white_lenses[#white_lenses] or 0
 	else
 		self.GoodInvationSignal = -1
 	end

--- a/lua/entities/gmod_track_signal/init.lua
+++ b/lua/entities/gmod_track_signal/init.lua
@@ -165,13 +165,13 @@ function MSignalSayHook(ply, comm, fromULX)
 			comm = comm:sub(8,-1):upper()
 			comm = string.Explode(":",comm)
 			if comm[1] == sig.Name then
-				sig.InvationSignal = true
+				if sig.GoodInvationSignal and sig.GoodInvationSignal > 0 then sig.InvationSignal = true end
 			end
 		elseif comm:sub(1,7) == "!sclps " then
 			comm = comm:sub(8,-1):upper()
 			comm = string.Explode(":",comm)
 			if comm[1] == sig.Name then
-				sig.InvationSignal = false
+				if sig.GoodInvationSignal and sig.GoodInvationSignal > 0 then sig.InvationSignal = false end
 			end
 		elseif comm:sub(1,7) == "!senao " then
 			comm = comm:sub(8,-1):upper()
@@ -304,19 +304,16 @@ function ENT:PostInitalize()
 		if not v.Lights then continue end
 		v.LightsExploded = string.Explode("-",v.Lights)
 	end
-	if not self.RouteNumberSetup or not self.RouteNumberSetup:find("W") then
-		self.GoodInvationSignal = 0
-		local index = 1
-		for k,v in ipairs(self.Lenses) do
-			if v ~= "M" then
-				for i = 1,#v do
-					if v[i] == "W" then self.GoodInvationSignal = index end
-					index = index + 1
-				end
-			end
+	self.GoodInvationSignal = 0
+	local index = 1
+	local after_red = false
+	for k,v in ipairs(self.Lenses) do
+		if v == "M" then continue end
+		for i = 1,#v do
+			if v[i] == "R" then after_red = true end
+			if v[i] == "W" and after_red then self.GoodInvationSignal = index end
+			index = index + 1
 		end
-	else
-		self.GoodInvationSignal = -1
 	end
 	if self.Left then
 		self:SetModel(self.TrafficLightModels[self.SignalType or 0].ArsBoxMittor.model)

--- a/lua/entities/gmod_track_signal/init.lua
+++ b/lua/entities/gmod_track_signal/init.lua
@@ -304,16 +304,20 @@ function ENT:PostInitalize()
 		if not v.Lights then continue end
 		v.LightsExploded = string.Explode("-",v.Lights)
 	end
-	self.GoodInvationSignal = 0
-	local index = 1
-	local after_red = false
-	for k,v in ipairs(self.Lenses) do
-		if v == "M" then continue end
-		for i = 1,#v do
-			if v[i] == "R" then after_red = true end
-			if v[i] == "W" and after_red then self.GoodInvationSignal = index end
-			index = index + 1
+	if not self.RouteNumberSetup or not self.RouteNumberSetup:find("W") then
+		self.GoodInvationSignal = 0
+		local index = 1
+		local after_red = false
+		for k,v in ipairs(self.Lenses) do
+			if v == "M" then continue end
+			for i = 1,#v do
+				if v[i] == "R" then after_red = true end
+				if v[i] == "W" and after_red then self.GoodInvationSignal = index end
+				index = index + 1
+			end
 		end
+	else
+		self.GoodInvationSignal = -1
 	end
 	if self.Left then
 		self:SetModel(self.TrafficLightModels[self.SignalType or 0].ArsBoxMittor.model)

--- a/lua/entities/gmod_track_signal/init.lua
+++ b/lua/entities/gmod_track_signal/init.lua
@@ -307,17 +307,14 @@ function ENT:PostInitalize()
 	if not self.RouteNumberSetup or not self.RouteNumberSetup:find("W") then
 		self.GoodInvationSignal = 0
 		local index = 1
-		local white_lenses = {}
-		local after_red = false
 		for k,v in ipairs(self.Lenses) do
 			if v != "M" then
 				for i = 1,#v do
-					if i == #v and v[i] == "W" then table.insert(white_lenses, index) end
+					if i == #v and v[i] == "W" then self.GoodInvationSignal = index end
 					index = index + 1
 				end
 			end
 		end
-		self.GoodInvationSignal = white_lenses[#white_lenses] or 0
 	else
 		self.GoodInvationSignal = -1
 	end


### PR DESCRIPTION
В текущей версии логика неверно назначает пригласительный сигнал на белую линзу. 
Если в светофоре указаны линзы "BWR", self.GoodInvationSignal = 2, а белая линза будет являться пригласительным сигналом и загорится по команде !sopps. Это неверно.

В рамках исправленной логики, self.GoodInvationSignal всегда равен 0 и изменит своё значение на индекс белой линзы, только в том случае, если она находится под красной линзой, что является необходимым и достаточным условием.
Так, для светофора линзами "WYG-RW", self.GoodInvationSignal = 5, и нижняя белая линза (из двух) будет являться ПСом. А в случае с "BWR", self.GoodInvationSignal = 0. 

Соответствующая проверка добавлена в команды !sopps и !sclps, на self.GoodInvationSignal > 0, чтобы ПС открывался/закрывался только на тех сигналах, где он действительно есть. 