### PR TITLE
Исправление логики назначения пригласительного сигнала

### DIFF
--- a/lua/entities/gmod_track_signal/init.lua
+++ b/lua/entities/gmod_track_signal/init.lua
@@ -165,13 +165,13 @@ function MSignalSayHook(ply, comm, fromULX)
 			comm = comm:sub(8,-1):upper()
 			comm = string.Explode(":",comm)
 			if comm[1] == sig.Name then
-				sig.InvationSignal = true
+				if sig.GoodInvationSignal and sig.GoodInvationSignal > 0 then sig.InvationSignal = true end
 			end
 		elseif comm:sub(1,7) == "!sclps " then
 			comm = comm:sub(8,-1):upper()
 			comm = string.Explode(":",comm)
 			if comm[1] == sig.Name then
-				sig.InvationSignal = false
+				if sig.GoodInvationSignal and sig.GoodInvationSignal > 0 then sig.InvationSignal = false end
 			end
 		elseif comm:sub(1,7) == "!senao " then
 			comm = comm:sub(8,-1):upper()
@@ -308,9 +308,9 @@ function ENT:PostInitalize()
 		self.GoodInvationSignal = 0
 		local index = 1
 		for k,v in ipairs(self.Lenses) do
-			if v ~= "M" then
+			if v != "M" then
 				for i = 1,#v do
-					if v[i] == "W" then self.GoodInvationSignal = index end
+					if i == #v and v[i] == "W" then self.GoodInvationSignal = index end
 					index = index + 1
 				end
 			end


### PR DESCRIPTION
В текущей версии логика неверно назначает пригласительный сигнал на белую линзу. 
Если в светофоре указаны линзы "BWR", self.GoodInvationSignal будет равен 2, а белая линза будет являться пригласительным сигналом и загорится по команде !sopps. Это неверно. 

В рамках исправленной логики, self.GoodInvationSignal всегда равен 0 и изменит своё значение на индекс белой линзы, только в том случае, если она является самой нижней в самой нижней светофорной секции и действительно предназначена для ПС. 
Примеры: 
1. WYY-GRW - ПС назначается на 6 линзу 
2. WRW - ПС назначается на 3 линзу 
3. WY-WR-W - ПС назначается на 5 линзу 
4. WR, BWR, YY-GR - ПС назначен не будет 

Соответствующая проверка на self.GoodInvationSignal > 0 добавлена в команды !sopps и !sclps, чтобы ПС открывался/закрывался только на тех сигналах, где он действительно есть. 

P.S. Эта проблема ранее уже обсуждалась в #456