### PR TITLE
Изменён тип рендера сидений и проведена микрооптимизация

### DIFF
--- a/lua/entities/gmod_subway_81-501/init.lua
+++ b/lua/entities/gmod_subway_81-501/init.lua
@@ -40,15 +40,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-502/init.lua
+++ b/lua/entities/gmod_subway_81-502/init.lua
@@ -48,15 +48,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-702/init.lua
+++ b/lua/entities/gmod_subway_81-702/init.lua
@@ -30,15 +30,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-53),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-702_int/init.lua
+++ b/lua/entities/gmod_subway_81-702_int/init.lua
@@ -29,15 +29,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-703/init.lua
+++ b/lua/entities/gmod_subway_81-703/init.lua
@@ -37,15 +37,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-703_int/init.lua
+++ b/lua/entities/gmod_subway_81-703_int/init.lua
@@ -38,15 +38,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-714_lvz/init.lua
+++ b/lua/entities/gmod_subway_81-714_lvz/init.lua
@@ -28,10 +28,8 @@ function ENT:Initialize()
     --self.InstructorsSeat = self:CreateSeat("instructor",Vector(430,47,-27+2.5),Angle(0,-90,0))
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    --self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    --self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    --self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-714_mvm/init.lua
+++ b/lua/entities/gmod_subway_81-714_mvm/init.lua
@@ -31,10 +31,8 @@ function ENT:Initialize()
     --self.InstructorsSeat = self:CreateSeat("instructor",Vector(430,47,-27+2.5),Angle(0,-90,0))
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    --self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    --self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    --self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-717_lvz/init.lua
+++ b/lua/entities/gmod_subway_81-717_lvz/init.lua
@@ -57,16 +57,11 @@ function ENT:Initialize()
     self.ExtraSeat3 = self:CreateSeat("instructor",Vector(402,50,-43),Angle(0,50,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat3:SetColor(Color(0,0,0,0))
-    self.ExtraSeat3:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat3:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-717_mvm/init.lua
+++ b/lua/entities/gmod_subway_81-717_mvm/init.lua
@@ -58,16 +58,11 @@ function ENT:Initialize()
     self.ExtraSeat3 = self:CreateSeat("instructor",Vector(402,50,-43),Angle(0,50,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat3:SetColor(Color(0,0,0,0))
-    self.ExtraSeat3:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat3:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-718/init.lua
+++ b/lua/entities/gmod_subway_81-718/init.lua
@@ -44,16 +44,11 @@ function ENT:Initialize()
     self.ExtraSeat3 = self:CreateSeat("instructor",Vector(402,50,-43),Angle(0,50,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat3:SetColor(Color(0,0,0,0))
-    self.ExtraSeat3:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat3:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-719/init.lua
+++ b/lua/entities/gmod_subway_81-719/init.lua
@@ -22,8 +22,7 @@ function ENT:Initialize()
     self.DriverSeat = self:CreateSeat("driver",Vector(-415-16,0,-48+2.5+6),Angle(0,-90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-720/init.lua
+++ b/lua/entities/gmod_subway_81-720/init.lua
@@ -53,16 +53,11 @@ function ENT:Initialize()
     self.InstructorsSeat4 = self:CreateSeat("instructor",Vector(425,-25,-50),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat2:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat3:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat3:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat4:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat4:SetColor(Color(0,0,0,0))
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat2:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat3:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat4:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-721/init.lua
+++ b/lua/entities/gmod_subway_81-721/init.lua
@@ -22,8 +22,7 @@ function ENT:Initialize()
     self.DriverSeat = self:CreateSeat("instructor",Vector(450,11,-35))
 
     -- Hide seats
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.DriverSeat:SetColor(Color(0,0,0,0))
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_81-722/init.lua
+++ b/lua/entities/gmod_subway_81-722/init.lua
@@ -58,16 +58,11 @@ function ENT:Initialize()
     self.InstructorsSeat4 = self:CreateSeat("instructor",Vector(455,-30,-50),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat2:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat3:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat3:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat4:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat4:SetColor(Color(0,0,0,0))
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat2:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat3:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat4:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     self.FrontBogey = self:CreateBogey(Vector( 322,0,-90),Angle(0,180,0),true,"722")

--- a/lua/entities/gmod_subway_81-723/init.lua
+++ b/lua/entities/gmod_subway_81-723/init.lua
@@ -20,8 +20,7 @@ function ENT:Initialize()
     self.DriverSeat = self:CreateSeat("instructor",Vector(450,11,-35))
 
     -- Hide seats
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.DriverSeat:SetColor(Color(0,0,0,0))
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     self.FrontBogey = self:CreateBogey(Vector( 322,0,-90),Angle(0,180,0),true,"722")

--- a/lua/entities/gmod_subway_81-724/init.lua
+++ b/lua/entities/gmod_subway_81-724/init.lua
@@ -20,8 +20,7 @@ function ENT:Initialize()
     self.DriverSeat = self:CreateSeat("instructor",Vector(450,11,-35))
 
     -- Hide seats
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.DriverSeat:SetColor(Color(0,0,0,0))
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     self.FrontBogey = self:CreateBogey(Vector( 322,0,-90),Angle(0,180,0),true,"722")

--- a/lua/entities/gmod_subway_em508/init.lua
+++ b/lua/entities/gmod_subway_em508/init.lua
@@ -35,15 +35,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_em508t/init.lua
+++ b/lua/entities/gmod_subway_em508t/init.lua
@@ -35,15 +35,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_em509/init.lua
+++ b/lua/entities/gmod_subway_em509/init.lua
@@ -39,15 +39,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_ezh/init.lua
+++ b/lua/entities/gmod_subway_ezh/init.lua
@@ -40,15 +40,11 @@ function ENT:Initialize()
     self.ExtraSeat1 = self:CreateSeat("instructor",Vector(443,0,-48+6+2.5),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_ezh1/init.lua
+++ b/lua/entities/gmod_subway_ezh1/init.lua
@@ -35,15 +35,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-48+6),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     if Metrostroi.BogeyOldMap then

--- a/lua/entities/gmod_subway_ezh3/init.lua
+++ b/lua/entities/gmod_subway_ezh3/init.lua
@@ -34,15 +34,11 @@ function ENT:Initialize()
     self.ExtraSeat2 = self:CreateSeat("instructor",Vector(420,-20,-52),Angle(0,90,0),"models/vehicles/prisoner_pod_inner.mdl")
 
     -- Hide seats
-    self.DriverSeat:SetColor(Color(0,0,0,0))
-    self.DriverSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.InstructorsSeat:SetColor(Color(0,0,0,0))
-    self.InstructorsSeat:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.DriverSeat:SetRenderMode(RENDERMODE_NONE)
+    self.InstructorsSeat:SetRenderMode(RENDERMODE_NONE)
 
-    self.ExtraSeat1:SetColor(Color(0,0,0,0))
-    self.ExtraSeat1:SetRenderMode(RENDERMODE_TRANSALPHA)
-    self.ExtraSeat2:SetColor(Color(0,0,0,0))
-    self.ExtraSeat2:SetRenderMode(RENDERMODE_TRANSALPHA)
+    self.ExtraSeat1:SetRenderMode(RENDERMODE_NONE)
+    self.ExtraSeat2:SetRenderMode(RENDERMODE_NONE)
 
     -- Create bogeys
     --.FrontBogey = self:CreateBogey(Vector( 320,0,-75),Angle(0,180,0),true)


### PR DESCRIPTION
Изменен тип рендера сидений во всех составах с RENDERMODE_TRANSALPHA на RENDERMODE_NONE, что не отдаёт "тени из ниоткуда", также удалены записи Color(0,0,0,0), что ускоряет загрузку сервера.

**Старый метод рендера нагружает клиент сильнее из-за отрисовки теней, лично я получил 1-2 фпс**

**Скриншот отсутствия посторонних теней**
![image](https://user-images.githubusercontent.com/77161824/166133216-0fbf83b9-56ea-4fdc-8d84-89a68e21e259.png)
