### PR TITLE
Кастомные знаки в сигнал туле

### DIFF
--- a/lua/entities/gmod_track_signs/cl_init.lua
+++ b/lua/entities/gmod_track_signs/cl_init.lua
@@ -72,9 +72,9 @@ function ENT:Think()
 	    --  --if ent.Spawned then hook.Remove("MetrostroiBigLag",ent) end
 	    --  --ent.Spawned = true
 	    --end)
-        if self:GetNWString("CustomModel",nil)then
-            self.Model = ClientsideModel(self:GetNWString("CustomModel",nil), RENDERGROUP_OTHER)
-        else
+        if self:GetNWString("CustomModel","") ~= "" then
+            self.Model = ClientsideModel(self:GetNWString("CustomModel"), RENDERGROUP_OTHER)
+        elseif self.ModelProp.model then
             if self.Left and not self.ModelProp.noleft then
                 if self.ModelProp.model:find("_r.mdl") then
                     self.Model = ClientsideModel(self.ModelProp.model:Replace("_r.mdl","_l.mdl"), RENDERGROUP_OTHER)

--- a/lua/entities/gmod_track_signs/cl_init.lua
+++ b/lua/entities/gmod_track_signs/cl_init.lua
@@ -87,6 +87,8 @@ function ENT:Think()
                 self.Model = ClientsideModel(self.ModelProp.model, RENDERGROUP_OTHER)
                 --self.Model:SetModel(self.ModelProp.model)
             end
+        else
+            return true
         end
 		local RAND = math.random(-10,10)
 		local pos = self.ModelProp.pos + self.Offset

--- a/lua/entities/gmod_track_signs/cl_init.lua
+++ b/lua/entities/gmod_track_signs/cl_init.lua
@@ -72,18 +72,22 @@ function ENT:Think()
 	    --  --if ent.Spawned then hook.Remove("MetrostroiBigLag",ent) end
 	    --  --ent.Spawned = true
 	    --end)
-		if self.Left and not self.ModelProp.noleft then
-			if self.ModelProp.model:find("_r.mdl") then
-				self.Model = ClientsideModel(self.ModelProp.model:Replace("_r.mdl","_l.mdl"), RENDERGROUP_OTHER)
-				--self.Model:SetModel(self.ModelProp.model:Replace("_r.mdl","_l.mdl"))
-			else
-				self.Model = ClientsideModel(self.ModelProp.model:Replace("_l.mdl","_r.mdl"), RENDERGROUP_OTHER)
-				--self.Model:SetModel(self.ModelProp.model:Replace("_l.mdl","_r.mdl"))
-			end
-		else
-			self.Model = ClientsideModel(self.ModelProp.model, RENDERGROUP_OTHER)
-			--self.Model:SetModel(self.ModelProp.model)
-		end
+        if self:GetNWString("CustomModel",nil)then
+            self.Model = ClientsideModel(self:GetNWString("CustomModel",nil), RENDERGROUP_OTHER)
+        else
+            if self.Left and not self.ModelProp.noleft then
+                if self.ModelProp.model:find("_r.mdl") then
+                    self.Model = ClientsideModel(self.ModelProp.model:Replace("_r.mdl","_l.mdl"), RENDERGROUP_OTHER)
+                    --self.Model:SetModel(self.ModelProp.model:Replace("_r.mdl","_l.mdl"))
+                else
+                    self.Model = ClientsideModel(self.ModelProp.model:Replace("_l.mdl","_r.mdl"), RENDERGROUP_OTHER)
+                    --self.Model:SetModel(self.ModelProp.model:Replace("_l.mdl","_r.mdl"))
+                end
+            else
+                self.Model = ClientsideModel(self.ModelProp.model, RENDERGROUP_OTHER)
+                --self.Model:SetModel(self.ModelProp.model)
+            end
+        end
 		local RAND = math.random(-10,10)
 		local pos = self.ModelProp.pos + self.Offset
 		local ang = self.ModelProp.angles

--- a/lua/entities/gmod_track_signs/shared.lua
+++ b/lua/entities/gmod_track_signs/shared.lua
@@ -509,3 +509,7 @@ ENT.SignModels[84] = {
 	angles = Angle(0,-90,0),
 	noauto = true,
 }
+ENT.SignModels[85] = {
+	pos = Vector(0,0,0),
+	angles = Angle(0,0,0)
+}

--- a/lua/metrostroi/sv_railnetwork.lua
+++ b/lua/metrostroi/sv_railnetwork.lua
@@ -1407,7 +1407,8 @@ function Metrostroi.Save(name)
     local signs_ents = ents.FindByClass("gmod_track_signs")
     for k,v in pairs(signs_ents) do
         local CustomModel
-        if IsValid(v) then CustomModel = v:GetNWString("CustomModel",nil)end
+        if IsValid(v) then CustomModel = v:GetNWString("CustomModel","")end
+        if CustomModel == "" then CustomModel = nil end
         table.insert(signs,{
             Class = "gmod_track_signs",
             Pos = v:GetPos(),

--- a/lua/metrostroi/sv_railnetwork.lua
+++ b/lua/metrostroi/sv_railnetwork.lua
@@ -1200,6 +1200,7 @@ local function loadSigns(name,keep)
                 ent.YOffset = v.YOffset
                 ent.ZOffset = v.ZOffset
                 ent.Left = v.Left,
+                ent:SetNWString("CustomModel",v.CustomModel)
                 ent:Spawn()
                 ent:SendUpdate()
             elseif v.Class == "gmod_track_signal" then ent:Remove() end
@@ -1405,6 +1406,8 @@ function Metrostroi.Save(name)
     end
     local signs_ents = ents.FindByClass("gmod_track_signs")
     for k,v in pairs(signs_ents) do
+        local CustomModel
+        if IsValid(v) then CustomModel = v:GetNWString("CustomModel",nil)end
         table.insert(signs,{
             Class = "gmod_track_signs",
             Pos = v:GetPos(),
@@ -1413,6 +1416,7 @@ function Metrostroi.Save(name)
             YOffset = v.YOffset,
             ZOffset = v.ZOffset,
             Left = v.Left,
+            CustomModel = CustomModel
         })
     end
     signs.Version = Metrostroi.SignalVersion

--- a/lua/weapons/gmod_tool/stools/signalling.lua
+++ b/lua/weapons/gmod_tool/stools/signalling.lua
@@ -925,6 +925,8 @@ function TOOL:BuildCPanelCustom()
                 tool.Sign.CustomModel = val
                 tool:SendSettings()
             end
+        else
+            tool.Sign.CustomModel = nil
         end
         local VYOffT = CPanel:NumSlider("Y Offset:",nil,-500,500,0)
             VYOffT:SetValue(tool.Sign.YOffset or 0)

--- a/lua/weapons/gmod_tool/stools/signalling.lua
+++ b/lua/weapons/gmod_tool/stools/signalling.lua
@@ -56,6 +56,7 @@ local TypesOfSign = {"NF","40","60","70","80","Station border","C(horn) Street",
     "Ted On 722 90%",
     "Ted On 722 100%",
     "Ted On Outside",
+    "Custom"
     }
 local RouteTypes = {"Auto", "Manual","Repeater","Emerg"}
 
@@ -185,6 +186,7 @@ function TOOL:SpawnSign(ply,trace,param)
         self.Sign.YOffset = ent.YOffset
         self.Sign.ZOffset = ent.ZOffset
         self.Sign.Left = ent.Left
+        self.Sign.CustomModel = ent:GetNWString("CustomModel",nil)
         net.Start("metrostroi-stool-signalling")
             net.WriteUInt(1,8)
             net.WriteTable(self.Sign)
@@ -208,6 +210,7 @@ function TOOL:SpawnSign(ply,trace,param)
             ent.YOffset = self.Sign.YOffset
             ent.ZOffset = self.Sign.ZOffset
             ent.Left = self.Sign.Left
+            ent:SetNWString("CustomModel",self.Sign.CustomModel)
             ent:SendUpdate()
         end
         return ent
@@ -908,27 +911,40 @@ function TOOL:BuildCPanelCustom()
                 VSType:SetValue(name)
                 tool.Sign.Type = index
                 tool:SendSettings()
+                self:BuildCPanelCustom()
             end
         CPanel:AddItem(VSType)
-        local VYOffT = CPanel:NumSlider("Y Offset:",nil,-100,100,0)
+        if tool.Sign.Type == #TypesOfSign then
+            local VNameT = CPanel:TextEntry("ModelPath")
+            VNameT:SetTooltip("example: models/metrostroi/re_sign/t_och_r.mdl")
+            VNameT:SetValue(tool.Sign.CustomModel or "")
+            VNameT:SetEnterAllowed(false)
+            function VNameT:OnLoseFocus()
+                tool.Sign.CustomModel = self:GetValue()
+                tool:SendSettings()
+            end
+        end
+        local VYOffT = CPanel:NumSlider("Y Offset:",nil,-500,500,0)
             VYOffT:SetValue(tool.Sign.YOffset or 0)
             VYOffT.OnValueChanged = function(num)
                 tool.Sign.YOffset = VYOffT:GetValue()
                 tool:SendSettings()
             end
-        local VZOffT = CPanel:NumSlider("Z Offset:",nil,-50,50,0)
+        local VZOffT = CPanel:NumSlider("Z Offset:",nil,-100,100,0)
             VZOffT:SetValue(tool.Sign.ZOffset or 0)
             VZOffT.OnValueChanged = function(num)
                 tool.Sign.ZOffset = VZOffT:GetValue()
                 tool:SendSettings()
             end
-        local VLeftOC = CPanel:CheckBox("Left side(if can be left-side)")
-                VLeftOC:SetTooltip("Left side")
-                VLeftOC:SetValue(tool.Sign.Left or false)
-                function VLeftOC:OnChange()
-                    tool.Sign.Left = self:GetChecked()
-                    tool:SendSettings()
-                end
+        if tool.Sign.Type ~= #TypesOfSign then
+            local VLeftOC = CPanel:CheckBox("Left side(if can be left-side)")
+                    VLeftOC:SetTooltip("Left side")
+                    VLeftOC:SetValue(tool.Sign.Left or false)
+                    function VLeftOC:OnChange()
+                        tool.Sign.Left = self:GetChecked()
+                        tool:SendSettings()
+                    end
+        end
     elseif tool.Type == 3 then
         --local VNotF = vgui.Create("DLabel") VNotF:SetText("Not Finished yet!!")
         local VAType = vgui.Create("DComboBox")

--- a/lua/weapons/gmod_tool/stools/signalling.lua
+++ b/lua/weapons/gmod_tool/stools/signalling.lua
@@ -916,11 +916,13 @@ function TOOL:BuildCPanelCustom()
         CPanel:AddItem(VSType)
         if tool.Sign.Type == #TypesOfSign then
             local VNameT = CPanel:TextEntry("ModelPath")
-            VNameT:SetTooltip("example: models/metrostroi/re_sign/t_och_r.mdl")
+            VNameT:SetTooltip("example: models/metrostroi/re_sign/t_och_r.mdl\nMax length 199")
             VNameT:SetValue(tool.Sign.CustomModel or "")
             VNameT:SetEnterAllowed(false)
             function VNameT:OnLoseFocus()
-                tool.Sign.CustomModel = self:GetValue()
+                local val = self:GetValue():gsub("\\","/")
+                self:SetText(val)
+                tool.Sign.CustomModel = val
                 tool:SendSettings()
             end
         end


### PR DESCRIPTION
При выборе в сигнал туле Sign Custom, появляется строка для ввода пути к модели. Немного увеличил диапазоны слайдеров. Максимально допустимая длина строки 199 символов. Этого должно хватить

Я не захотел добавлять возможность оффсетов, чтобы не увеличивать число сетевых значений (правда одно все-таки добавил). И не захотел делать добавление SignModels (как в shared файле) для простоты использования. То есть угол придется выставлять моделерам на этапе моделирования