### PR TITLE
Allow train entities to opt out of automatic rerailing

### DIFF
--- a/lua/metrostroi/sh_rerail.lua
+++ b/lua/metrostroi/sh_rerail.lua
@@ -293,7 +293,7 @@ function Metrostroi.RerailTrain(train)
 	train.RearBogey:SetAngles(train:LocalToWorldAngles(train.RearBogey.SpawnAng))--reardata.forward:Angle())
 
 
-	if IsValid(train.FrontCouple) and not train.OptOutRerail then
+	if IsValid(train.FrontCouple) and train.OptOutRerail ~=nil then
 		train.FrontCouple:SetPos(train:LocalToWorld(train.FrontCouple.SpawnPos))
 		train.RearCouple:SetPos(train:LocalToWorld(train.RearCouple.SpawnPos))
 		train.FrontCouple:SetAngles(train:LocalToWorldAngles(train.FrontCouple.SpawnAng))

--- a/lua/metrostroi/sh_rerail.lua
+++ b/lua/metrostroi/sh_rerail.lua
@@ -293,12 +293,15 @@ function Metrostroi.RerailTrain(train)
 	train.RearBogey:SetAngles(train:LocalToWorldAngles(train.RearBogey.SpawnAng))--reardata.forward:Angle())
 
 
-	if IsValid(train.FrontCouple) then
+	if IsValid(train.FrontCouple) and not train.OptOutRerail then
 		train.FrontCouple:SetPos(train:LocalToWorld(train.FrontCouple.SpawnPos))
 		train.RearCouple:SetPos(train:LocalToWorld(train.RearCouple.SpawnPos))
 		train.FrontCouple:SetAngles(train:LocalToWorldAngles(train.FrontCouple.SpawnAng))
 		train.RearCouple:SetAngles(train:LocalToWorldAngles(train.RearCouple.SpawnAng))
 
+		train.FrontCouple:GetPhysicsObject():EnableMotion(false)
+		train.RearCouple:GetPhysicsObject():EnableMotion(false)
+	elseif IsValid(train.FrontCouple) and train.OptOutRerail == true then
 		train.FrontCouple:GetPhysicsObject():EnableMotion(false)
 		train.RearCouple:GetPhysicsObject():EnableMotion(false)
 	end


### PR DESCRIPTION
Custom trains, particularly long, three+-section articulated ones face issues if the couplers are parented onto the correct sections. Not parenting them onto the sections they belong to leads to an incorrect application of the axis/ballsocket constraints, making the couplers sag to the ground. However the rerail routines incorrectly calculate the positioning for moving the couplers based on the main entity, making the whole contraption glitch out.

For reference, my design for eight axle trains is such:

A-C-B

C being the brain of the train while B and A are control cars to the logic in the mid section. Spawning from the middle outward also gives the advantage of avoiding further physics weirdness. For now, this is a small hack that won't affect Mainline Metrostroi trains and the rerail code doesn't have to be changed in greater detail.

![image](https://github.com/metrostroi-repo/MetrostroiAddon/assets/5427724/30338629-abb3-4aa0-b789-be74efa890a6)
![image](https://github.com/metrostroi-repo/MetrostroiAddon/assets/5427724/bc819e0a-7c1f-454d-8482-5c5055756e3a)
