### PR TITLE
Fix loopline pto display name

### DIFF
--- a/lua/metrostroi/maps/loopline.lua
+++ b/lua/metrostroi/maps/loopline.lua
@@ -571,7 +571,7 @@ Metrostroi.StationConfigurations = {
         }
     },
     pto = {
-        pto = {"пто","ПТО"},
+        names = {"пто","ПТО"},
         positions = {
             {Vector(-4539,5624,-4597),Angle(0,0,0)},
         }


### PR DESCRIPTION
fixes `bad argument ​#1 to 'concat' (table expected, got nil)` ([cl_stations.lua](https://github.com/metrostroi-repo/MetrostroiAddon/blob/dev/lua/metrostroi/cl_stations.lua#L35))