### PR TITLE
Hide GUI when capturing RT #597

### DIFF
--- a/lua/metrostroi/cl_util.lua
+++ b/lua/metrostroi/cl_util.lua
@@ -936,6 +936,8 @@ concommand.Add("metrostroi_capture_rt",function(_,_,args)
     local train = LocalPlayer().InMetrostroiTrain
     if not IsValid(train) then return end
 
+    gui.HideGameUI()
+
     local oldRt = render.GetRenderTarget() -- we'll save the old screen and draw on a new one!
     file.CreateDir("rt_captures")
     for i,v in ipairs(RTs) do


### PR DESCRIPTION
Фикс для #597
Надо проверить, но суть ясна.

Не смотря на статус deprecated, эта команда всё ещё активно используется самой игрой.