### PR TITLE
Фикс расчёта электрики 81-710, 81-717

### DIFF
--- a/lua/metrostroi/systems/sys_81_710_electric.lua
+++ b/lua/metrostroi/systems/sys_81_710_electric.lua
@@ -527,7 +527,7 @@ function TRAIN_SYSTEM:SolveThyristorController(Train, dT,iter)
             self.ThyristorState = 0.92
             if I > 130 then--I > T * 0.9 then
                 self.PrepareElectric = false
-                self.ThyristorState = (1 - math.max(0, math.min(1, ((Train.Engines.Speed - 50) / 32)) ^ 0.5)) * 0.9
+                self.ThyristorState = (1 - math.max(0, math.min(1, (math.max(0, Train.Engines.Speed - 50) / 32)) ^ 0.5)) * 0.9
             end
         else
             self.ThyristorState = math.max(0, math.min(1, self.ThyristorState + dC / rnd * dT))

--- a/lua/metrostroi/systems/sys_81_717_electric.lua
+++ b/lua/metrostroi/systems/sys_81_717_electric.lua
@@ -1130,7 +1130,7 @@ function TRAIN_SYSTEM:SolveThyristorController(Train, dT)
             self.ThyristorState = 0.92
             if I > 162 then--I > T * 0.9 then
                 self.PrepareElectric = false
-                self.ThyristorState = (1 - math.max(0, math.min(1, ((Train.Engines.Speed - 50) / 32)) ^ 0.5)) * 0.9
+                self.ThyristorState = (1 - math.max(0, math.min(1, (math.max(0, Train.Engines.Speed - 50) / 32)) ^ 0.5)) * 0.9
             end
         else
             self.ThyristorState = math.max(0, math.min(1, self.ThyristorState + dC / rnd * dT))


### PR DESCRIPTION
`(Train.Engines.Speed - 50)` может быть меньше нуля, в результате чего получается так, что берется корень из отрицательного числа