### PR TITLE
Замена self:GetOwner() на self:GetPlayer()

### DIFF
--- a/lua/entities/gmod_subway_base/init.lua
+++ b/lua/entities/gmod_subway_base/init.lua
@@ -57,7 +57,7 @@ function ENT:PostEntityPaste(ply,ent,createdEntities)
             v[1].NoPhysics = v[2] or nil
 
             -- Assign ownership
-            if IsValid(self:GetOwner()) then v[1]:SetOwner(self:GetOwner()) end
+            if IsValid(self:GetPlayer()) then v[1]:SetPlayer(self:GetPlayer()) end
             if CPPI and IsValid(self:CPPIGetOwner()) then v[1]:CPPISetOwner(self:CPPIGetOwner()) end
 
             -- Some shared general information about the bogey
@@ -107,7 +107,7 @@ function ENT:Initialize()
     self:SetUseType(SIMPLE_USE)
     -- Prop-protection related
     if IsValid(self.Owner) then
-        self:SetOwner(self.Owner)
+        self:SetPlayer(self.Owner)
         if CPPI then self:CPPISetOwner(self.Owner) end
     end
     -- Entities that belong to train and must be cleaned up later
@@ -1034,7 +1034,7 @@ function ENT:CreateBogey(pos,ang,forward,typ)
     bogey:Spawn()
 
     -- Assign ownership
-    if IsValid(self:GetOwner()) then bogey:SetOwner(self:GetOwner()) end
+    if IsValid(self:GetPlayer()) then bogey:SetPlayer(self:GetPlayer()) end
     if CPPI and IsValid(self:CPPIGetOwner()) then bogey:CPPISetOwner(self:CPPIGetOwner()) end
 
     -- Some shared general information about the bogey
@@ -1072,7 +1072,7 @@ function ENT:CreateBogey(pos,ang,forward,typ)
 end
 function ENT:AddLightSensor(pos,ang,model)
     local sensor = ents.Create("gmod_train_autodrive_coil")
-    if IsValid(self:GetOwner()) then sensor:SetOwner(self:GetOwner()) end
+    if IsValid(self:GetPlayer()) then sensor:SetPlayer(self:GetPlayer()) end
     if CPPI and IsValid(self:CPPIGetOwner()) then sensor:CPPISetOwner(self:CPPIGetOwner()) end
     sensor:SetPos(self:LocalToWorld(pos))
     sensor:SetAngles(self:LocalToWorldAngles(ang))
@@ -1095,7 +1095,7 @@ function ENT:AddAutodriveCoil(bogey,right)
             bogey.CoilL = coil
         end
     -- Assign ownership
-        if IsValid(self:GetOwner()) then coil:SetOwner(self:GetOwner()) end
+        if IsValid(self:GetPlayer()) then coil:SetPlayer(self:GetPlayer()) end
         if CPPI and IsValid(self:CPPIGetOwner()) then coil:CPPISetOwner(self:CPPIGetOwner()) end
     end
     if right then
@@ -1121,7 +1121,7 @@ function ENT:CreateCouple(pos,ang,forward,typ)
     coupler:Spawn()
 
     -- Assign ownership
-    if IsValid(self:GetOwner()) then coupler:SetOwner(self:GetOwner()) end
+    if IsValid(self:GetPlayer()) then coupler:SetPlayer(self:GetPlayer()) end
     if CPPI and IsValid(self:CPPIGetOwner()) then coupler:CPPISetOwner(self:CPPIGetOwner()) end
 
     -- Some shared general information about the bogey
@@ -1194,7 +1194,7 @@ function ENT:CreateSeatEntity(seat_info)
     self:DrawShadow(false)
 
     --Assign ownership
-    if IsValid(self:GetOwner()) then seat:SetOwner(self:GetOwner()) end
+    if IsValid(self:GetPlayer()) then seat:SetOwner(self:GetPlayer()) end
     if CPPI and IsValid(self:CPPIGetOwner()) then seat:CPPISetOwner(self:CPPIGetOwner()) end
 
     -- Hide the entity visually

--- a/lua/entities/gmod_subway_base/shared.lua
+++ b/lua/entities/gmod_subway_base/shared.lua
@@ -1,5 +1,5 @@
 ENT.Type            = "anim"
-
+ENT.Base            = "base_gmodentity"
 ENT.Author          = ""
 ENT.Contact         = ""
 ENT.Purpose         = ""

--- a/lua/entities/gmod_train_autodrive_coil/shared.lua
+++ b/lua/entities/gmod_train_autodrive_coil/shared.lua
@@ -1,5 +1,5 @@
 ENT.Type            = "anim"
-
+ENT.Base            = "base_gmodentity"
 ENT.PrintName       = "Autodrive coil"
 ENT.Category		= "Metrostroi (utility)"
 

--- a/lua/entities/gmod_train_bogey/init.lua
+++ b/lua/entities/gmod_train_bogey/init.lua
@@ -151,10 +151,10 @@ function ENT:InitializeWheels()
     end
 
     -- Assign ownership
-    if IsValid(self:GetOwner()) then
-        wheels:SetOwner(self:GetOwner())
-    elseif IsValid(self:GetNW2Entity("TrainEntity"):GetOwner()) then
-        wheels:SetOwner(self:GetNW2Entity("TrainEntity"):GetOwner())
+    if IsValid(self:GetPlayer()) then
+        wheels:SetPlayer(self:GetPlayer())
+    elseif IsValid(self:GetNW2Entity("TrainEntity"):GetPlayer()) then
+        wheels:SetPlayer(self:GetNW2Entity("TrainEntity"):GetPlayer())
     end
 
     if CPPI and IsValid(self:CPPIGetOwner()) then

--- a/lua/entities/gmod_train_bogey/shared.lua
+++ b/lua/entities/gmod_train_bogey/shared.lua
@@ -1,5 +1,5 @@
 ENT.Type            = "anim"
-
+ENT.Base            = "base_gmodentity"
 ENT.Author          = ""
 ENT.Contact         = ""
 ENT.Purpose         = ""

--- a/lua/entities/gmod_train_couple/shared.lua
+++ b/lua/entities/gmod_train_couple/shared.lua
@@ -1,5 +1,5 @@
 ENT.Type            = "anim"
-
+ENT.Base            = "base_gmodentity"
 ENT.Author          = ""
 ENT.Contact         = ""
 ENT.Purpose         = ""

--- a/lua/entities/gmod_train_special_box/init.lua
+++ b/lua/entities/gmod_train_special_box/init.lua
@@ -34,11 +34,10 @@ function ENT:Use(_,ply)
         self.Cover:SetPos(self:LocalToWorld(Vector(0,0,5.7)))
         self.Cover:SetAngles(self:GetAngles())
         self.Cover:Spawn()
-        self.Cover:SetOwner(self.Owner)
         local phys = self.Cover:GetPhysicsObject()
         phys:ApplyForceCenter(self.Cover:GetUp()*phys:GetMass()*40+self.Cover:GetRight()*phys:GetMass()*35 )
         if IsValid(self.Owner) then
-            self.Cover:SetOwner(self.Owner)
+            self.Cover:SetPlayer(self.Owner)
             if CPPI then self.Cover:CPPISetOwner(self.Owner) end
         end
         if self.Code then self:SetNW2Int("Code",self.Code) end

--- a/lua/entities/gmod_train_special_box/shared.lua
+++ b/lua/entities/gmod_train_special_box/shared.lua
@@ -1,5 +1,5 @@
 ENT.Type            = "anim"
-
+ENT.Base            = "base_gmodentity"
 ENT.PrintName       = "Special box"
 ENT.Author          = ""
 ENT.Contact         = ""

--- a/lua/entities/gmod_train_wheels/shared.lua
+++ b/lua/entities/gmod_train_wheels/shared.lua
@@ -1,5 +1,5 @@
 ENT.Type            = "anim"
-
+ENT.Base            = "base_gmodentity"
 ENT.PrintName       = "Train Wheels"
 ENT.Author          = ""
 ENT.Contact         = ""

--- a/lua/metrostroi/sv_debugger.lua
+++ b/lua/metrostroi/sv_debugger.lua
@@ -60,7 +60,7 @@ concommand.Add("metrostroi_debugtrainsystems", cmdinithandler, nil, "Add aimed a
 
 -- Automatically engage debugger for train owner
 function Metrostroi.DebugTrain(train,ply)
-	if not ply then ply = train:GetOwner() end
+	if not ply then ply = train:GetPlayer() end
 	if (not IsValid(train)) or (not IsValid(ply)) then return end
 
 	AddClient(ply,train)

--- a/lua/ulx/modules/sh/metrostroi.lua
+++ b/lua/ulx/modules/sh/metrostroi.lua
@@ -108,7 +108,7 @@ function ulx.trains( calling_ply, ToP )
         for k2,ent in pairs(ents) do
             if ent.NoTrain or trains[ent] or (ent.FrontTrain and ent.RearTrain) or not ent.WagonList then continue end
 
-            local owner = CPPI and ent:CPPIGetOwner() or ent:GetOwner()
+            local owner = CPPI and ent:CPPIGetOwner() or ent:GetPlayer()
             local canShow = not ToP or ToP == "" or IsValid(owner) and owner:GetName():find(ToP)
 
             if not canShow and not tonumber(ToP) then continue end
@@ -181,7 +181,7 @@ function ulx.traingoto( calling_ply, ToP)
         for k2,ent in pairs(ents) do
             if ent.NoTrain then continue end
 
-            local owner = CPPI and ent:CPPIGetOwner() or ent:GetOwner()
+            local owner = CPPI and ent:CPPIGetOwner() or ent:GetPlayer()
             local driver = ent:GetDriver()
             if not ToS and owner == calling_ply and not (ent.FrontTrain and ent.RearTrain) then train = ent break end
             if ToS and driver and driver:GetName():find(ToS) and not ulx.getExclusive(driver,calling_ply) then train = ent break end


### PR DESCRIPTION
resolve #595 
self:GetOwner() отключает взаимодействие с поездом, а следовательно для игрока он прозрачен
Добавлен базовый класс "base_gmodentity", в котором реализовано self:GetPlayer()/SetPlayer()