### PR TITLE
Фикс сцепки при спавне

### DIFF
--- a/lua/entities/gmod_train_couple/init.lua
+++ b/lua/entities/gmod_train_couple/init.lua
@@ -315,8 +315,7 @@ end
 
 local vector_zero = Vector(0, 0, 0)
 function ENT:Think()
-    local train = self:GetNW2Entity("TrainEntity")
-    if IsValid(train) and train.OnCoupled and not IsValid(self.Coupled) then
+    if self.TrainSpawnerCoupleFix then
         -- Fixing crazy physics on spawn
         local phy = self:GetPhysicsObject()
         if IsValid(phy) then

--- a/lua/entities/gmod_train_couple/init.lua
+++ b/lua/entities/gmod_train_couple/init.lua
@@ -313,7 +313,18 @@ function ENT:OnDecouple()
     end
 end
 
+local vector_zero = Vector(0, 0, 0)
 function ENT:Think()
-    self:NextThink(CurTime()+1)
+    local train = self:GetNW2Entity("TrainEntity")
+    if IsValid(train) and train.OnCoupled and not IsValid(self.Coupled) then
+        -- Fixing crazy physics on spawn
+        local phy = self:GetPhysicsObject()
+        if IsValid(phy) then
+            phy:SetAngleVelocityInstantaneous(vector_zero)
+        end
+        self:NextThink(CurTime())
+    else
+        self:NextThink(CurTime() + 1)
+    end
     return true
 end

--- a/lua/weapons/gmod_tool/stools/train_spawner.lua
+++ b/lua/weapons/gmod_tool/stools/train_spawner.lua
@@ -327,6 +327,12 @@ function TOOL:SpawnWagon(trace)
         ent:UpdateTextures()
         ent.FrontAutoCouple = i > 1 and i < self.Settings.WagNum
         ent.RearAutoCouple = self.Settings.WagNum > 1
+        if IsValid(ent.FrontCouple) then
+            ent.FrontCouple.TrainSpawnerCoupleFix = ent.FrontAutoCouple
+        end
+        if IsValid(ent.RearCouple) then
+            ent.RearCouple.TrainSpawnerCoupleFix = ent.RearAutoCouple
+        end
         LastEnt = ent
     end
     undo.SetPlayer(ply)
@@ -342,6 +348,8 @@ function TOOL:SpawnWagon(trace)
                 train.RearBogey.BrakeCylinderPressure = 3
                 train.FrontBogey.MotorPower = 0
                 train.RearBogey.MotorPower = 0
+                train.FrontCouple.TrainSpawnerCoupleFix = nil
+                train.RearCouple.TrainSpawnerCoupleFix = nil
                 train.OnCoupled = nil
             end
             timer.Simple(1,function() for i,train in ipairs(trains) do train.IgnoreEngine = false end end)


### PR DESCRIPTION
Исправлена сломавшаяся физика сцепки после обновления гмода.
Угловая скорость сцепки задается в ноль, пока действует TrainSpawner. Как флаг его работы, использовано поле `OnCoupled` и проверка на то, не сцеплены ли мы уже.

Этот фикс также починил сцепку и на x86_64 ветке Гмода в одиночной игре.