### PR TITLE
Повышение стабильности фикса сцепки

### DIFF
--- a/lua/entities/gmod_train_couple/init.lua
+++ b/lua/entities/gmod_train_couple/init.lua
@@ -313,13 +313,12 @@ function ENT:OnDecouple()
     end
 end
 
-local vector_zero = Vector(0, 0, 0)
 function ENT:Think()
     if self.TrainSpawnerCoupleFix then
         -- Fixing crazy physics on spawn
         local phy = self:GetPhysicsObject()
         if IsValid(phy) then
-            phy:SetAngleVelocityInstantaneous(vector_zero)
+            phy:SetAngleVelocityInstantaneous(-phy:GetAngleVelocity())
         end
         self:NextThink(CurTime())
     else


### PR DESCRIPTION
На воркшопной версии метростроя обнаружилось, что на некоторых картах при спавне 6-ти и более вагонов, оригинального фикса не достаточно.

Однако, на гитхаб-версии такого (по крайней мере мной) обнаружено не было. **Оставлю этот ПР как драфт пока что, пока эта проблема не подтвердится в этой версии.**

Стоит заметить, что с оригинальным фиксом дрифт сцепки все еще присутствует, хоть и малый (и вроде как такой был всегда, до обновления 29 апр). С фиксом же из этого коммита, дрифт отсутствует вовсе.

Также есть опасение, что этот коммит может понизить стабильность работы фикса, в виду вмешательста в физику, так что нужно больше тестов. Однако в моих тестах все работает идеально.